### PR TITLE
Refactor frame generation to support multiple sizes

### DIFF
--- a/src/png.rs
+++ b/src/png.rs
@@ -3,12 +3,21 @@ use image::codecs::ico::IcoFrame;
 
 use crate::cli;
 
+/// Generates [`IcoFrame`]s from a PNG file
+/// This function takes a file path and a list of sizes, and generates ICO frames for each size.
 pub fn generate_frames(args: &cli::Args) -> anyhow::Result<Vec<IcoFrame>> {
     let img = image::open(&args.input).context("failed to open file")?;
-
-    let img = img.resize(16, 16, image::imageops::FilterType::Lanczos3);
-    let rgba = img.to_rgba8();
-    let frame = IcoFrame::as_png(&rgba, 16, 16, image::ExtendedColorType::Rgba8)
-        .context("failed to make ico frame")?;
-    Ok(vec![frame])
+    let frames: Vec<IcoFrame> = args
+        .sizes
+        .iter()
+        .map(|size| -> Result<IcoFrame<'_>, anyhow::Error> {
+            let img = img.resize(*size, *size, image::imageops::FilterType::Lanczos3);
+            let rgba = img.to_rgba8();
+            Ok(
+                IcoFrame::as_png(&rgba, *size, *size, image::ExtendedColorType::Rgba8)
+                    .context("failed to make ico frame")?,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(frames)
 }

--- a/src/png.rs
+++ b/src/png.rs
@@ -11,7 +11,7 @@ pub fn generate_frames(args: &cli::Args) -> anyhow::Result<Vec<IcoFrame>> {
         .sizes
         .iter()
         .map(|size| -> Result<IcoFrame<'_>, anyhow::Error> {
-            let img = img.resize(*size, *size, image::imageops::FilterType::Lanczos3);
+            let img = img.resize_exact(*size, *size, image::imageops::FilterType::Lanczos3);
             let rgba = img.to_rgba8();
             Ok(
                 IcoFrame::as_png(&rgba, *size, *size, image::ExtendedColorType::Rgba8)

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -8,8 +8,16 @@ use crate::cli;
 pub fn generate_frames(args: &cli::Args) -> anyhow::Result<Vec<IcoFrame>> {
     let file_contents = std::fs::read(&args.input)?;
     let tree = usvg::Tree::from_data(&file_contents, &usvg::Options::default())?;
-    let frame = generate_frame(&tree, 256)?;
-    Ok(vec![frame])
+    let frames = args
+        .sizes
+        .iter()
+        .map(|size| -> Result<IcoFrame<'_>, anyhow::Error> {
+            let size = *size as usize;
+            generate_frame(&tree, size)
+                .context(format!("failed to generate frame for size {}", size))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(frames)
 }
 
 /// Rasterizes the given [SVG tree][usvg::Tree] into an [`IcoFrame`] of given `size`


### PR DESCRIPTION
The changes refactor the `generate_frames` function to handle multiple sizes for ICO frames.

Ensure accurate frame dimensions by using `resize_exact`. This addresses the buffer length mismatch issue when resizing images. Fixes #2